### PR TITLE
Add support for PyPy, Python 2.7, and Python 3.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+bin
+build
+dist
+lib
+parts
+
+*.dll
+*.pyc
+*.pyo
+*.so
+*.egg
+.installed.cfg
+eggs
+.eggs
+*.egg-info
+develop-eggs
+.dir-locals.el

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ eggs
 *.egg-info
 develop-eggs
 .dir-locals.el
+.tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,12 @@
 language: python
 sudo: false
 python:
+    - pypy
     - 2.6
     - 2.7
+    - 3.2
+    - 3.3
+    - 3.4
 install:
     - pip install .
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
     - 3.2
     - 3.3
     - 3.4
+    - pypy3
 install:
     - pip install .
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: python
+sudo: false
+python:
+    - 2.6
+    - 2.7
+install:
+    - pip install .
+script:
+    - python setup.py test -q
+notifications:
+    email: false

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,0 @@
-Changelog
-=========
-
-0.6.2 (unreleased)
-----------------
-
-- Add support for PyPy, Python 2.7, and Python 3.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,0 +1,7 @@
+Changelog
+=========
+
+0.6.2 (unreleased)
+----------------
+
+- Add support for PyPy and Python 3.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,4 +4,4 @@ Changelog
 0.6.2 (unreleased)
 ----------------
 
-- Add support for PyPy and Python 3.
+- Add support for PyPy, Python 2.7, and Python 3.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,9 @@
+include *.txt
+include *.rst
+
+recursive-include src *
+
+global-exclude *.dll
+global-exclude *.pyc
+global-exclude *.pyo
+global-exclude *.so

--- a/setup.py
+++ b/setup.py
@@ -45,13 +45,14 @@ install_requires = [
     "transaction",
     ]
 
-# PyPy and Py3K don't have cPickle's `noload`, and `noload` is broken in CPython >= 2.7
+# PyPy, Jython, and Py3K don't have cPickle's `noload`, and `noload` is broken in CPython >= 2.7
 py_impl = getattr(platform, 'python_implementation', lambda: None)
 is_pypy = py_impl() == 'PyPy'
+is_jython = py_impl() == 'Jython'
 py3k = sys.version_info >= (3, )
 py27 = sys.version_info >= (2, 7)
 
-if is_pypy or py27 or py3k:
+if is_pypy or is_jython or py27 or py3k:
     install_requires.append('zodbpickle')
 
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@
 #
 ##############################################################################
 
-name, version = 'zc.zodbdgc', '0'
+name, version = 'zc.zodbdgc', '0.6.2.dev0'
 
 import os
 import platform
@@ -63,7 +63,7 @@ setup(
     long_description=long_description,
     license = 'ZPL 2.1',
 
-    packages = find_packages('src'),
+    packages = ['zc', 'zc.zodbdgc'],
     namespace_packages = ['zc'],
     package_dir = {'': 'src'},
     install_requires=install_requires,
@@ -83,6 +83,9 @@ setup(
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.6",
         "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: Implementation :: CPython",
+        "Programming Language :: Python :: Implementation :: PyPy",
     ],
     )

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,8 @@
 name, version = 'zc.zodbdgc', '0'
 
 import os
+import platform
+import sys
 from setuptools import setup, find_packages
 
 entry_points = """
@@ -35,6 +37,22 @@ long_description = (
         )
 
 tests_require = ['zope.testing', 'mock']
+install_requires = [
+    "ZODB",
+    "persistent",
+    "transaction",
+    "BTrees",
+    "setuptools"]
+
+# PyPy and Py3K don't have cPickle's `noload`, and `noload` is broken in CPython >= 2.7
+py_impl = getattr(platform, 'python_implementation', lambda: None)
+is_pypy = py_impl() == 'PyPy'
+py3k = sys.version_info >= (3, )
+py27 = sys.version_info >= (2, 7)
+
+if is_pypy or py27 or py3k:
+    install_requires.append('zodbpickle')
+
 
 setup(
     name = name,
@@ -48,7 +66,7 @@ setup(
     packages = find_packages('src'),
     namespace_packages = ['zc'],
     package_dir = {'': 'src'},
-    install_requires = ['setuptools', 'ZODB3 >=3.9.0b2'],
+    install_requires=install_requires,
     zip_safe = False,
     entry_points=entry_points,
     include_package_data = True,
@@ -57,4 +75,14 @@ setup(
         test=tests_require,
         ),
     test_suite='zc.zodbdgc.tests.test_suite',
+	classifiers=[
+        "Framework :: ZODB"
+        "License :: OSI Approved :: Zope Public License",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 2.6",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: Implementation :: CPython",
+    ],
     )

--- a/setup.py
+++ b/setup.py
@@ -38,11 +38,12 @@ long_description = (
 
 tests_require = ['zope.testing', 'mock']
 install_requires = [
-    "ZODB",
-    "persistent",
+    "BTrees >= 4.0.0",
+    "ZODB >= 4.0.0",
+    "persistent >= 4.0.0",
+    "setuptools",
     "transaction",
-    "BTrees",
-    "setuptools"]
+    ]
 
 # PyPy and Py3K don't have cPickle's `noload`, and `noload` is broken in CPython >= 2.7
 py_impl = getattr(platform, 'python_implementation', lambda: None)
@@ -84,6 +85,8 @@ setup(
         "Programming Language :: Python :: 2.6",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.2",
+        "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",

--- a/src/zc/zodbdgc/README.test
+++ b/src/zc/zodbdgc/README.test
@@ -20,7 +20,8 @@ We'll need to control time.
 
 Let's define some storages::
 
-    >>> open('config', 'w').write("""
+    >>> f = open('config', 'w')
+    >>> _ = f.write("""
     ... <zodb db1>
     ...     <filestorage>
     ...         pack-gc false
@@ -44,6 +45,7 @@ Let's define some storages::
     ...     </filestorage>
     ... </zodb>
     ... """)
+    >>> f.close()
 
     >>> import ZODB.blob, ZODB.config, transaction
     >>> db = ZODB.config.databaseFromFile(open('config'))
@@ -100,10 +102,14 @@ cross db loops
 No garbage yet, because everything's reachable.
 
     >>> from ZODB.utils import u64, p64
-    >>> print u64(conn1.root.a._p_oid), u64(conn1.root.b._p_oid)
-    2204 2205
-    >>> print u64(conn2.root.x._p_oid), u64(conn3.root.x._p_oid)
-    1 2
+    >>> print( u64(conn1.root.a._p_oid) )
+    2204
+    >>> print( u64(conn1.root.b._p_oid) )
+    2205
+    >>> print( u64(conn2.root.x._p_oid) )
+    1
+    >>> print( u64(conn3.root.x._p_oid) )
+    2
     >>> del conn1.root.a
     >>> del conn1.root.b
     >>> del conn2.root.x
@@ -137,15 +143,17 @@ We'll create some more garbage:
 
     >>> transaction.commit()
 
-    >>> print u64(conn2.root.a._p_oid), u64(conn2.root.b._p_oid)
-    3 4
+    >>> print( u64(conn2.root.a._p_oid) )
+    3
+    >>> print( u64(conn2.root.b._p_oid) )
+    4
     >>> del conn2.root.a
     >>> del conn2.root.b
     >>> transaction.commit()
 
 Let's add a blob.  We'll use it later:
 
-    >>> conn1.root.blob = ZODB.blob.Blob('some data')
+    >>> conn1.root.blob = ZODB.blob.Blob(b'some data')
     >>> transaction.commit()
     >>> blob_path = conn1.root.blob.committed()
 
@@ -154,11 +162,11 @@ Save databases for later:
 
     >>> import shutil
     >>> for n in range(1, 4):
-    ...     shutil.copyfile('%s.fs' % n, '%s.fs-save' %n)
+    ...     _ = shutil.copyfile('%s.fs' % n, '%s.fs-save' %n)
 
 More time passes.
 
-    >>> now += 1 * 86400
+    >>> now += 1
 
 The number of objects in the databases now:
 
@@ -184,8 +192,8 @@ Packing doesn't change it:
 Save databases for later:
 
     >>> for n in range(1, 4):
-    ...     shutil.copyfile('%s.fs' % n, '%s.fs-2' %n)
-    >>> shutil.copytree('1.blobs', '1.blobs-2')
+    ...     _ = shutil.copyfile('%s.fs' % n, '%s.fs-2' %n)
+    >>> _ = shutil.copytree('1.blobs', '1.blobs-2')
     >>> shutil.copymode('1.blobs', '1.blobs-2')
 
 Now let's perform gc.
@@ -194,7 +202,7 @@ Now let's perform gc.
     >>> bad = zc.zodbdgc.gc('config', days=2)
 
     >>> for name, oid in sorted(bad.iterator()):
-    ...     print name, u64(oid)
+    ...     print( "{0} {1}".format( name, u64(oid)) )
     db1 2204
     db1 2205
     db1 2206
@@ -239,7 +247,7 @@ haven't packed yet.
     ...     except ZODB.POSException.POSKeyError:
     ...         pass
     ...     else:
-    ...         print 'waaa', name, u64(oid)
+    ...         print( 'waaa', name, u64(oid) )
 
 Make sure we have no broken refs:
 
@@ -251,12 +259,13 @@ First restore the databases.
 
     >>> import os
     >>> for n in range(1, 4):
-    ...     shutil.copyfile('%s.fs-2' % n, '%s.fs' % n)
+    ...     _ = shutil.copyfile('%s.fs-2' % n, '%s.fs' % n)
     ...     os.remove('%s.fs.index' % n)
 
 Make a secondary config:
 
-    >>> open('config2', 'w').write("""
+    >>> f = open('config2', 'w')
+    >>> _ = f.write("""
     ... <zodb db1>
     ...     <filestorage>
     ...         path 1.fs-2
@@ -274,6 +283,7 @@ Make a secondary config:
     ...     </filestorage>
     ... </zodb>
     ... """)
+    >>> f.close()
 
 
 This time we'll use the command-line interface:
@@ -364,7 +374,7 @@ logging:
     >>> old_argv = sys.argv[:]
     >>> old_basicConfig = logging.basicConfig
     >>> def faux_basicConfig(level=None, format=None):
-    ...     print 'basicConfig', (), dict(level=level)
+    ...     print('basicConfig () {0}'.format(dict(level=level)))
     >>> logging.basicConfig = faux_basicConfig
 
     >>> sys.argv[:] = ['-d2', 'config']
@@ -439,7 +449,7 @@ and check -l option handling:
 Make sure we can omit days on the command line:
 
     >>> for n in range(1, 4):
-    ...     shutil.copyfile('%s.fs' % n, '%s.fs-2' %n)
+    ...     _ = shutil.copyfile('%s.fs' % n, '%s.fs-2' %n)
     ...     os.remove('%s.fs-2.index' % n)
 
     >>> sorted(zc.zodbdgc.gc_command(['config', 'config2']).iterator())
@@ -485,7 +495,7 @@ Test the check command
     >>> os.remove(blob_path.replace('1.blobs', '1.blobs-2'))
 
     >>> for n in range(1, 4):
-    ...     shutil.copyfile('%s.fs-save' % n, '%s.fs-2' %n)
+    ...     _ = shutil.copyfile('%s.fs-save' % n, '%s.fs-2' %n)
     ...     os.remove('%s.fs-2.index' % n)
     >>> db = ZODB.config.databaseFromFile(open('config2'))
 
@@ -517,10 +527,12 @@ query about any references:
     >>> refs = zc.zodbdgc.References('refs.fs')
     >>> list(refs['db2', 2])
     [('db1', 1)]
-    >>> list(refs['db2', '\0'*7+'\2'])
+    >>> list(refs['db2', b'\0'*7+b'\2'])
     [('db1', 1)]
     >>> list(refs['db1', 1])
     [('db1', 0)]
+    >>> transaction.abort()
+    >>> refs.close()
 
 
 
@@ -531,7 +543,8 @@ incorrectly removed as garbage.
 
 If we see references to databases we haven't heard of, we just report them:
 
-    >>> open('config2', 'w').write("""
+    >>> f = open('config2', 'w')
+    >>> _ = f.write("""
     ... <zodb db1>
     ...     <filestorage>
     ...         path 1.fs-2
@@ -539,6 +552,7 @@ If we see references to databases we haven't heard of, we just report them:
     ...     </filestorage>
     ... </zodb>
     ... """)
+    >>> f.close()
 
     >>> zc.zodbdgc.check_command(['config2']) #doctest: +ELLIPSIS
     !!! db1 2216 ?
@@ -552,7 +566,8 @@ available at the time the bad reference is detected.)
 If a database is configured to not allow cross references, we complain
 about cross references that we see:
 
-    >>> open('config2', 'w').write("""
+    >>> f = open('config2', 'w')
+    >>> _ = f.write("""
     ... <zodb db1>
     ...     allow-implicit-cross-references false
     ...     <filestorage>
@@ -573,6 +588,7 @@ about cross references that we see:
     ...     </filestorage>
     ... </zodb>
     ... """)
+    >>> f.close()
 
     >>> zc.zodbdgc.check_command(['config2']) #doctest: +ELLIPSIS
     !!! db1 2216 ?
@@ -623,15 +639,17 @@ databases.
 
     >>> db.pack()
 
-    >>> _ = [db.close() for db in db.databases.itervalues()]
+    >>> _ = [db.close() for db in db.databases.values()]
 
-    >>> open('config', 'w').write("""
+    >>> f = open('config', 'w')
+    >>> _ = f.write("""
     ... <zodb db1>
     ...     <filestorage>
     ...         path one.fs
     ...     </filestorage>
     ... </zodb>
     ... """)
+    >>> f.close()
 
     >>> sorted(zc.zodbdgc.gc_command(['config']).iterator())
     Traceback (most recent call last):
@@ -639,13 +657,13 @@ databases.
     KeyError: 'db2'
 
     >>> sorted(zc.zodbdgc.gc_command(['-idb2', 'config']).iterator())
-    ... # doctest: +NORMALIZE_WHITESPACE
+    ... # doctest: +NORMALIZE_WHITESPACE, +ELLIPSIS
     db1: roots
     db1: recent
     db1: remove garbage
     Removed 2 objects from db1
-    [('db1', '\x00\x00\x00\x00\x00\x00\x00\x02'),
-     ('db1', '\x00\x00\x00\x00\x00\x00\x00\x03')]
+    [('db1', ...'\x00\x00\x00\x00\x00\x00\x00\x02'),
+     ('db1', ...'\x00\x00\x00\x00\x00\x00\x00\x03')]
 
     >>> os.remove('one.fs')
     >>> os.remove('two.fs')
@@ -659,7 +677,8 @@ If the database under analysis is a file-storage, we can access the
 files directly:
 
 
-    >>> open('config', 'w').write("""
+    >>> f = open('config', 'w')
+    >>> _ = f.write("""
     ... <zodb db1>
     ...     <filestorage>
     ...         path one.fs
@@ -673,6 +692,7 @@ files directly:
     ...     </filestorage>
     ... </zodb>
     ... """)
+    >>> f.close()
     >>> db = ZODB.config.databaseFromFile(open('config'))
     >>> conn = db.open()
     >>> conn.get_connection('db2').root.x = C()
@@ -694,12 +714,12 @@ files directly:
 
     >>> db.pack()
 
-    >>> _ = [db.close() for db in db.databases.itervalues()]
+    >>> _ = [db.close() for db in db.databases.values()]
 
 
     >>> sorted(zc.zodbdgc.gc_command(['-fdb1=one.fs', '-fdb2=two.fs', 'config']
     ... ).iterator())
-    ... # doctest: +NORMALIZE_WHITESPACE
+    ... # doctest: +NORMALIZE_WHITESPACE,+ELLIPSIS
     db1: roots
     db1: recent
     db2: roots
@@ -708,8 +728,8 @@ files directly:
     Removed 2 objects from db1
     db2: remove garbage
     Removed 0 objects from db2
-    [('db1', '\x00\x00\x00\x00\x00\x00\x00\x02'),
-     ('db1', '\x00\x00\x00\x00\x00\x00\x00\x03')]
+    [('db1', ...'\x00\x00\x00\x00\x00\x00\x00\x02'),
+     ('db1', ...'\x00\x00\x00\x00\x00\x00\x00\x03')]
 
     >>> os.remove('one.fs')
     >>> os.remove('two.fs')

--- a/src/zc/zodbdgc/README.test
+++ b/src/zc/zodbdgc/README.test
@@ -216,8 +216,6 @@ Now let's perform gc.
     db1 2214
     db1 2215
     db2 1
-    db2 3
-    db2 4
     db3 1
     db3 2
 
@@ -238,7 +236,7 @@ haven't packed yet.
     ...     d.pack()
 
     >>> len(conn1._storage), len(conn2._storage), len(conn3._storage)
-    (2205, 2, 2)
+    (2205, 4, 2)
 
     >>> import ZODB.POSException
     >>> for name, oid in bad.iterator():
@@ -331,7 +329,7 @@ This time we'll use the command-line interface:
     db1: remove garbage
     Removed 12 objects from db1
     db2: remove garbage
-    Removed 3 objects from db2
+    Removed 1 objects from db2
     db3: remove garbage
     Removed 2 objects from db3
 
@@ -364,7 +362,7 @@ We can gc again, even with deleted records:
     ...     d.pack()
 
     >>> len(conn1._storage), len(conn2._storage), len(conn3._storage)
-    (2205, 2, 2)
+    (2205, 4, 2)
 
     >>> _ = [d.close() for d in db.databases.values()]
 
@@ -470,7 +468,7 @@ Make sure we can omit days on the command line:
 
 Try with 0 days:
 
-    >>> sorted((name, long(u64(oid))) for (name, oid) in
+    >>> sorted((name, int(u64(oid))) for (name, oid) in
     ...        zc.zodbdgc.gc_command(['-d0', 'config', 'config2']).iterator())
     Using secondary configuration, config2, for analysis
     db1: roots
@@ -479,10 +477,10 @@ Try with 0 days:
     db1: remove garbage
     Removed 0 objects from db1
     db2: remove garbage
-    Removed 0 objects from db2
+    Removed 2 objects from db2
     db3: remove garbage
     Removed 0 objects from db3
-    []
+    [('db2', 3), ('db2', 4)]
 
 Test the check command
 ----------------------

--- a/src/zc/zodbdgc/README.test
+++ b/src/zc/zodbdgc/README.test
@@ -158,7 +158,7 @@ Save databases for later:
 
 More time passes.
 
-    >>> now += 1
+    >>> now += 1 * 86400
 
 The number of objects in the databases now:
 
@@ -208,6 +208,8 @@ Now let's perform gc.
     db1 2214
     db1 2215
     db2 1
+    db2 3
+    db2 4
     db3 1
     db3 2
 
@@ -228,7 +230,7 @@ haven't packed yet.
     ...     d.pack()
 
     >>> len(conn1._storage), len(conn2._storage), len(conn3._storage)
-    (2205, 4, 2)
+    (2205, 2, 2)
 
     >>> import ZODB.POSException
     >>> for name, oid in bad.iterator():
@@ -319,7 +321,7 @@ This time we'll use the command-line interface:
     db1: remove garbage
     Removed 12 objects from db1
     db2: remove garbage
-    Removed 1 objects from db2
+    Removed 3 objects from db2
     db3: remove garbage
     Removed 2 objects from db3
 
@@ -352,7 +354,7 @@ We can gc again, even with deleted records:
     ...     d.pack()
 
     >>> len(conn1._storage), len(conn2._storage), len(conn3._storage)
-    (2205, 4, 2)
+    (2205, 2, 2)
 
     >>> _ = [d.close() for d in db.databases.values()]
 
@@ -467,10 +469,10 @@ Try with 0 days:
     db1: remove garbage
     Removed 0 objects from db1
     db2: remove garbage
-    Removed 2 objects from db2
+    Removed 0 objects from db2
     db3: remove garbage
     Removed 0 objects from db3
-    [('db2', 3L), ('db2', 4L)]
+    []
 
 Test the check command
 ----------------------
@@ -492,9 +494,9 @@ Test the check command
     >>> for d in db.databases.values():
     ...     d.close()
 
-    >>> zc.zodbdgc.check_command(['config2'])
+    >>> zc.zodbdgc.check_command(['config2']) #doctest: +ELLIPSIS
     !!! db1 2216 ?
-    POSKeyError: 'No blob file'
+    POSKeyError: ...No blob file at ...
     !!! db2 2 ?
     POSKeyError: 0x02
 
@@ -502,9 +504,9 @@ We get a list of missing objects.  We don't get the referring objects.
 To get the, we have to use the -r option to specify the name of a
 database to use.
 
-    >>> zc.zodbdgc.check_command(['-rrefs.fs', 'config2'])
+    >>> zc.zodbdgc.check_command(['-rrefs.fs', 'config2']) #doctest: +ELLIPSIS
     !!! db1 2216 db1 0
-    POSKeyError: 'No blob file'
+    POSKeyError: ...No blob file...
     !!! db2 2 db1 1
     POSKeyError: 0x02
 
@@ -538,9 +540,9 @@ If we see references to databases we haven't heard of, we just report them:
     ... </zodb>
     ... """)
 
-    >>> zc.zodbdgc.check_command(['config2'])
+    >>> zc.zodbdgc.check_command(['config2']) #doctest: +ELLIPSIS
     !!! db1 2216 ?
-    POSKeyError: 'No blob file'
+    POSKeyError: ...No blob file...
     !!! db2 2 db1 1
     bad db
 
@@ -572,9 +574,9 @@ about cross references that we see:
     ... </zodb>
     ... """)
 
-    >>> zc.zodbdgc.check_command(['config2'])
+    >>> zc.zodbdgc.check_command(['config2']) #doctest: +ELLIPSIS
     !!! db1 2216 ?
-    POSKeyError: 'No blob file'
+    POSKeyError: ...No blob file...
     bad xref db2 2 db1 1
     !!! db2 2 ?
     POSKeyError: 0x02

--- a/src/zc/zodbdgc/README.test
+++ b/src/zc/zodbdgc/README.test
@@ -20,8 +20,8 @@ We'll need to control time.
 
 Let's define some storages::
 
-    >>> f = open('config', 'w')
-    >>> _ = f.write("""
+    >>> with open('config', 'w') as f:
+    ...     _ = f.write("""
     ... <zodb db1>
     ...     <filestorage>
     ...         pack-gc false
@@ -45,10 +45,11 @@ Let's define some storages::
     ...     </filestorage>
     ... </zodb>
     ... """)
-    >>> f.close()
+
 
     >>> import ZODB.blob, ZODB.config, transaction
-    >>> db = ZODB.config.databaseFromFile(open('config'))
+    >>> with open('config', 'r') as f:
+    ...     db = ZODB.config.databaseFromFile(f)
 
 And perform some updates:
 
@@ -219,7 +220,8 @@ Now let's perform gc.
     db3 1
     db3 2
 
-    >>> db = ZODB.config.databaseFromFile(open('config'))
+    >>> with open('config', 'r') as f:
+    ...    db = ZODB.config.databaseFromFile(f)
     >>> conn1 = db.open()
     >>> conn2 = conn1.get_connection('db2')
     >>> conn3 = conn1.get_connection('db3')
@@ -262,8 +264,8 @@ First restore the databases.
 
 Make a secondary config:
 
-    >>> f = open('config2', 'w')
-    >>> _ = f.write("""
+    >>> with open('config2', 'w') as f:
+    ...     _ = f.write("""
     ... <zodb db1>
     ...     <filestorage>
     ...         path 1.fs-2
@@ -281,7 +283,6 @@ Make a secondary config:
     ...     </filestorage>
     ... </zodb>
     ... """)
-    >>> f.close()
 
 
 This time we'll use the command-line interface:
@@ -353,7 +354,8 @@ We can gc again, even with deleted records:
     Removed 0 objects from db3
     []
 
-    >>> db = ZODB.config.databaseFromFile(open('config'))
+    >>> with open('config', 'r') as f:
+    ...     db = ZODB.config.databaseFromFile(f)
     >>> conn1 = db.open()
     >>> conn2 = conn1.get_connection('db2')
     >>> conn3 = conn1.get_connection('db3')
@@ -495,7 +497,8 @@ Test the check command
     >>> for n in range(1, 4):
     ...     _ = shutil.copyfile('%s.fs-save' % n, '%s.fs-2' %n)
     ...     os.remove('%s.fs-2.index' % n)
-    >>> db = ZODB.config.databaseFromFile(open('config2'))
+    >>> with open('config2', 'r') as f:
+    ...     db = ZODB.config.databaseFromFile(f)
 
     >>> for d in db.databases.values():
     ...     d.pack()
@@ -541,8 +544,8 @@ incorrectly removed as garbage.
 
 If we see references to databases we haven't heard of, we just report them:
 
-    >>> f = open('config2', 'w')
-    >>> _ = f.write("""
+    >>> with open('config2', 'w') as f:
+    ...    _ = f.write("""
     ... <zodb db1>
     ...     <filestorage>
     ...         path 1.fs-2
@@ -550,7 +553,6 @@ If we see references to databases we haven't heard of, we just report them:
     ...     </filestorage>
     ... </zodb>
     ... """)
-    >>> f.close()
 
     >>> zc.zodbdgc.check_command(['config2']) #doctest: +ELLIPSIS
     !!! db1 2216 ?
@@ -564,8 +566,8 @@ available at the time the bad reference is detected.)
 If a database is configured to not allow cross references, we complain
 about cross references that we see:
 
-    >>> f = open('config2', 'w')
-    >>> _ = f.write("""
+    >>> with open('config2', 'w') as f:
+    ...     _ = f.write("""
     ... <zodb db1>
     ...     allow-implicit-cross-references false
     ...     <filestorage>
@@ -586,7 +588,6 @@ about cross references that we see:
     ...     </filestorage>
     ... </zodb>
     ... """)
-    >>> f.close()
 
     >>> zc.zodbdgc.check_command(['config2']) #doctest: +ELLIPSIS
     !!! db1 2216 ?
@@ -639,15 +640,14 @@ databases.
 
     >>> _ = [db.close() for db in db.databases.values()]
 
-    >>> f = open('config', 'w')
-    >>> _ = f.write("""
+    >>> with open('config', 'w') as f:
+    ...     _ = f.write("""
     ... <zodb db1>
     ...     <filestorage>
     ...         path one.fs
     ...     </filestorage>
     ... </zodb>
     ... """)
-    >>> f.close()
 
     >>> sorted(zc.zodbdgc.gc_command(['config']).iterator())
     Traceback (most recent call last):
@@ -675,8 +675,8 @@ If the database under analysis is a file-storage, we can access the
 files directly:
 
 
-    >>> f = open('config', 'w')
-    >>> _ = f.write("""
+    >>> with open('config', 'w') as f:
+    ...     _ = f.write("""
     ... <zodb db1>
     ...     <filestorage>
     ...         path one.fs
@@ -690,8 +690,8 @@ files directly:
     ...     </filestorage>
     ... </zodb>
     ... """)
-    >>> f.close()
-    >>> db = ZODB.config.databaseFromFile(open('config'))
+    >>> with open('config', 'r') as f:
+    ...     db = ZODB.config.databaseFromFile(f)
     >>> conn = db.open()
     >>> conn.get_connection('db2').root.x = C()
     >>> transaction.commit()

--- a/src/zc/zodbdgc/README.test
+++ b/src/zc/zodbdgc/README.test
@@ -102,13 +102,13 @@ cross db loops
 No garbage yet, because everything's reachable.
 
     >>> from ZODB.utils import u64, p64
-    >>> print( u64(conn1.root.a._p_oid) )
+    >>> print(u64(conn1.root.a._p_oid))
     2204
-    >>> print( u64(conn1.root.b._p_oid) )
+    >>> print(u64(conn1.root.b._p_oid))
     2205
-    >>> print( u64(conn2.root.x._p_oid) )
+    >>> print(u64(conn2.root.x._p_oid))
     1
-    >>> print( u64(conn3.root.x._p_oid) )
+    >>> print(u64(conn3.root.x._p_oid))
     2
     >>> del conn1.root.a
     >>> del conn1.root.b
@@ -143,9 +143,9 @@ We'll create some more garbage:
 
     >>> transaction.commit()
 
-    >>> print( u64(conn2.root.a._p_oid) )
+    >>> print(u64(conn2.root.a._p_oid))
     3
-    >>> print( u64(conn2.root.b._p_oid) )
+    >>> print(u64(conn2.root.b._p_oid))
     4
     >>> del conn2.root.a
     >>> del conn2.root.b
@@ -202,7 +202,7 @@ Now let's perform gc.
     >>> bad = zc.zodbdgc.gc('config', days=2)
 
     >>> for name, oid in sorted(bad.iterator()):
-    ...     print( "{0} {1}".format( name, u64(oid)) )
+    ...     print("{0} {1}".format( name, u64(oid)))
     db1 2204
     db1 2205
     db1 2206
@@ -245,7 +245,7 @@ haven't packed yet.
     ...     except ZODB.POSException.POSKeyError:
     ...         pass
     ...     else:
-    ...         print( 'waaa', name, u64(oid) )
+    ...         print('waaa', name, u64(oid))
 
 Make sure we have no broken refs:
 

--- a/src/zc/zodbdgc/README.txt
+++ b/src/zc/zodbdgc/README.txt
@@ -72,6 +72,12 @@ information.
 Change History
 ==============
 
+0.6.2 (unreleased)
+----------------
+
+- Add support for PyPy, Python 2.7, and Python 3.
+
+
 0.6.1 2012-10-08
 ----------------
 

--- a/src/zc/zodbdgc/__init__.py
+++ b/src/zc/zodbdgc/__init__.py
@@ -471,7 +471,9 @@ def _insert_ref(references, rname, roid, name, oid):
         # Setting _p_changed is needed when using older versions of
         # the pure-python BTree package (e.g., under PyPy). This is
         # a bug documented at https://github.com/zopefoundation/BTrees/pull/11.
-        # Without it, the References example in README.test fails.
+        # Without it, the References example in README.test fails
+        # with a KeyError: the 'db2' key is not found because it wasn't
+        # persisted to disk.
         references._p_changed = True
     by_rname = by_oid.get(oid)
     if not by_rname:

--- a/src/zc/zodbdgc/__init__.py
+++ b/src/zc/zodbdgc/__init__.py
@@ -470,7 +470,7 @@ def _insert_ref(references, rname, roid, name, oid):
         by_oid = references[name] = BTrees.LOBTree.BTree()
         # XXX: Setting _p_changed is needed when using the pure-python
         # BTree package (e.g., under PyPy). This is probably a bug in
-        # BTree (LOBTreePy)? Without it, the References example in README.test
+        # BTree (OOBTreePy)? Without it, the References example in README.test
         # fails.
         references._p_changed = True
     by_rname = by_oid.get(oid)

--- a/src/zc/zodbdgc/__init__.py
+++ b/src/zc/zodbdgc/__init__.py
@@ -44,6 +44,7 @@ from io import BytesIO
 import logging
 import marshal
 import optparse
+from persistent import TimeStamp
 import struct
 import sys
 import tempfile
@@ -54,7 +55,7 @@ import ZODB.config
 import ZODB.FileStorage
 import ZODB.fsIndex
 import ZODB.POSException
-import ZODB.TimeStamp
+
 
 
 
@@ -161,12 +162,9 @@ def gc_(close, conf, days, ignore, conf2, fs, untransform, ptid):
     storages = sorted((name, d.storage) for (name, d) in databases.items())
 
     if ptid is None:
-        ptid = repr(
-            ZODB.TimeStamp.TimeStamp(
+        ptid = TimeStamp.TimeStamp(
                 *time.gmtime(time.time() - 86400*days)[:6]
-                ))
-        if not isinstance(ptid, bytes):
-            ptid = ptid.encode('ascii')
+                ).raw()
 
     good = oidset(databases)
     bad = Bad(databases)

--- a/src/zc/zodbdgc/__init__.py
+++ b/src/zc/zodbdgc/__init__.py
@@ -468,10 +468,10 @@ def _insert_ref(references, rname, roid, name, oid):
     by_oid = references.get(name)
     if not by_oid:
         by_oid = references[name] = BTrees.LOBTree.BTree()
-        # XXX: Setting _p_changed is needed when using the pure-python
-        # BTree package (e.g., under PyPy). This is probably a bug in
-        # BTree (OOBTreePy)? Without it, the References example in README.test
-        # fails.
+        # Setting _p_changed is needed when using older versions of
+        # the pure-python BTree package (e.g., under PyPy). This is
+        # a bug documented at https://github.com/zopefoundation/BTrees/pull/11.
+        # Without it, the References example in README.test fails.
         references._p_changed = True
     by_rname = by_oid.get(oid)
     if not by_rname:

--- a/src/zc/zodbdgc/__init__.py
+++ b/src/zc/zodbdgc/__init__.py
@@ -16,7 +16,21 @@ from ZODB.utils import z64
 import BTrees.fsBTree
 import BTrees.OOBTree
 import BTrees.LLBTree
-import cPickle
+try:
+    import zodbpickle
+except ImportError:
+    import cPickle
+else:
+    # We're on a platform where we needed zodbpickle
+    # because of a broken/missing noload.
+    # (or the user just happened to have it installed)
+    # In that case, use the fastest version we can have access
+    # to (PyPy doesn't have fastpickle)
+    try:
+        from zodbpickle import fastpickle as cPickle
+    except ImportError:
+        from zodbpickle import pickle as cPickle
+
 import cStringIO
 import logging
 import marshal

--- a/src/zc/zodbdgc/__init__.py
+++ b/src/zc/zodbdgc/__init__.py
@@ -601,7 +601,7 @@ class References(object):
 
     def __getitem__(self, arg):
         name, oid = arg
-        if isinstance(oid, (str,bytes)):
+        if isinstance(oid, (str, bytes)):
             oid = u64(oid)
         by_rname = self._refs[name][oid]
         if isinstance(by_rname, dict):

--- a/src/zc/zodbdgc/oidset.test
+++ b/src/zc/zodbdgc/oidset.test
@@ -92,84 +92,84 @@ name/oid pairs efficiently.
     >>> import pprint
 
     >>> pprint.pprint(
-    ...     sorted((name, long(u64(oid))) for (name, oid) in oids.iterator()),
+    ...     sorted((name, int(u64(oid))) for (name, oid) in oids.iterator()),
     ...     width=1)
     [('foo',
-      0L),
+      0),
      ('foo',
-      2147483647L),
+      2147483647),
      ('foo',
-      2147483648L),
+      2147483648),
      ('foo',
-      2147483649L),
+      2147483649),
      ('foo',
-      4294967296L),
+      4294967296),
      ('foo',
-      17179869184L),
+      17179869184),
      ('foo',
-      34359738368L)]
+      34359738368)]
 
     >>> pprint.pprint(
-    ...     sorted(long(u64(oid)) for oid in oids.iterator('foo')),
+    ...     sorted(int(u64(oid)) for oid in oids.iterator('foo')),
     ...     width=1)
-    [0L,
-     2147483647L,
-     2147483648L,
-     2147483649L,
-     4294967296L,
-     17179869184L,
-     34359738368L]
+    [0,
+     2147483647,
+     2147483648,
+     2147483649,
+     4294967296,
+     17179869184,
+     34359738368]
 
     >>> for oid in oids.iterator('foo'):
     ...     if not oids.insert('bar', oid):
-    ...         print `oid`
+    ...         print(repr(oid))
 
     >>> sorted(oids.iterator('foo')) == sorted(oids.iterator('bar'))
     True
 
     >>> pprint.pprint(
-    ...     sorted((name, long(u64(oid))) for (name, oid) in oids.iterator()),
+    ...     sorted((name, int(u64(oid))) for (name, oid) in oids.iterator()),
     ...     width=1)
     [('bar',
-      0L),
+      0),
      ('bar',
-      2147483647L),
+      2147483647),
      ('bar',
-      2147483648L),
+      2147483648),
      ('bar',
-      2147483649L),
+      2147483649),
      ('bar',
-      4294967296L),
+      4294967296),
      ('bar',
-      17179869184L),
+      17179869184),
      ('bar',
-      34359738368L),
+      34359738368),
      ('foo',
-      0L),
+      0),
      ('foo',
-      2147483647L),
+      2147483647),
      ('foo',
-      2147483648L),
+      2147483648),
      ('foo',
-      2147483649L),
+      2147483649),
      ('foo',
-      4294967296L),
+      4294967296),
      ('foo',
-      17179869184L),
+      17179869184),
      ('foo',
-      34359738368L)]
+      34359738368)]
 
     >>> oids.remove('foo', p64(1<<31))
     >>> oids.remove('foo', p64((1<<31)+1))
     >>> oids.remove('foo', p64((1<<31)-1))
 
     >>> pprint.pprint(
-    ...     sorted(long(u64(oid)) for oid in oids.iterator('foo')),
+    ...     sorted(int(u64(oid)) for oid in oids.iterator('foo')),
     ...     width=1)
-    [0L,
-     4294967296L,
-     17179869184L,
-     34359738368L]
+    [0,
+     4294967296,
+     17179869184,
+     34359738368]
 
     >>> import random
     >>> r = random.Random()
@@ -183,12 +183,12 @@ name/oid pairs efficiently.
     ...     name = r.choice(('foo', 'bar'))
     ...     oid = p64(r.randint(0, 1<<32))
     ...     if (name, oid) in generated_oids:
-    ...         print 'dup', (name, oid)
+    ...         print( 'dup', (name, oid) )
     ...         if oids.insert(name, oid):
-    ...            print 'wth dup', name, `oid`
+    ...            print( 'wth dup', name, repr(oid) )
     ...     else:
     ...         if not oids.insert(name, oid):
-    ...             print 'wth', name, `oid`
+    ...             print( 'wth', name, repr(oid) )
     ...         generated_oids.append((name, oid))
 
     >>> sorted(generated_oids) == sorted(oids.iterator())
@@ -199,7 +199,7 @@ name/oid pairs efficiently.
     ...     choice = r.choice(generated_oids)
     ...     if action == 'i':
     ...         if oids.insert(*choice):
-    ...             print 'wth', choice
+    ...             print( 'wth', choice )
     ...     else:
     ...         generated_oids.remove(choice)
     ...         oids.remove(*choice)

--- a/src/zc/zodbdgc/tests.py
+++ b/src/zc/zodbdgc/tests.py
@@ -22,13 +22,13 @@ import zc.zodbdgc
 import ZODB.config
 
 def untransform(data):
-    if data[:2] == '.h':
+    if data[:2] == b'.h':
         data = binascii.a2b_hex(data[2:])
     return data
 
 def hex_pack(self, pack_time, referencesf, *args):
     def refs(p, oids=None):
-        if p and p[:2] == '.h':
+        if p and p[:2] == b'.h':
             p = binascii.a2b_hex(p[2:])
         return referencesf(p, oids)
     return self.base.pack(pack_time, refs, *args)
@@ -46,7 +46,8 @@ untransform data records when accessing the file-storage file directly.
 
 First, open a database and create some data:
 
-    >>> open('config', 'w').write('''
+    >>> f = open('config', 'w')
+    >>> _ = f.write('''
     ... %import ZODB.tests
     ... <zodb>
     ...   <hexstorage>
@@ -57,6 +58,7 @@ First, open a database and create some data:
     ...   </hexstorage>
     ... </zodb>
     ... ''')
+    >>> f.close()
     >>> db = ZODB.config.databaseFromFile(open('config'))
     >>> conn = db.open()
     >>> for i in range(9):
@@ -99,10 +101,10 @@ Now GC. We should lose 3 objects:
     >>> import pprint
     >>> pprint.pprint(list(zc.zodbdgc.gc_command(
     ...   '-f=data.fs -uzc.zodbdgc.tests:untransform config'
-    ...   .split(), ptid).iterator()))
-    [('', '\x00\x00\x00\x00\x00\x00\x00\x01'),
-     ('', '\x00\x00\x00\x00\x00\x00\x00\x02'),
-     ('', '\x00\x00\x00\x00\x00\x00\x00\x03')]
+    ...   .split(), ptid).iterator())) #doctest: +ELLIPSIS
+    [('', ...'\x00\x00\x00\x00\x00\x00\x00\x01'),
+     ('', ...'\x00\x00\x00\x00\x00\x00\x00\x02'),
+     ('', ...'\x00\x00\x00\x00\x00\x00\x00\x03')]
 
     >>> db = ZODB.config.databaseFromFile(open('config'))
     >>> db.pack()
@@ -114,7 +116,8 @@ Now GC. We should lose 3 objects:
 def stupid_typo_nameerror_not():
     """
 
-    >>> open('config', 'w').write('''
+    >>> f = open('config', 'w')
+    >>> _ = f.write('''
     ... <zodb db>
     ...     <filestorage>
     ...         pack-gc false
@@ -123,6 +126,7 @@ def stupid_typo_nameerror_not():
     ...     </filestorage>
     ... </zodb>
     ... ''')
+    >>> f.close()
     >>> import persistent.mapping, time
     >>> with mock.patch("time.time", return_value=1241458549.614022):
     ...     db = ZODB.config.databaseFromFile(open('config'))
@@ -144,7 +148,7 @@ def stupid_typo_nameerror_not():
     ...     from ZODB.utils import u64
     ...     bad = zc.zodbdgc.gc('config', days=1)
     ...     for name, oid in sorted(bad.iterator()):
-    ...         print name, u64(oid)
+    ...         print( "{0} {1}".format(name, u64(oid)) )
     ...     time.time.return_value += 86400*1.5
     ...     db = ZODB.config.databaseFromFile(open('config'))
     ...     len(db.storage)
@@ -158,7 +162,8 @@ def stupid_typo_nameerror_not():
 
 def test_missmatched_configs():
     """
-    >>> open('config1', 'w').write('''
+    >>> f = open('config1', 'w')
+    >>> _ = f.write('''
     ... <zodb>
     ...     <filestorage>
     ...         pack-gc false
@@ -167,7 +172,9 @@ def test_missmatched_configs():
     ...     </filestorage>
     ... </zodb>
     ... ''')
-    >>> open('config2', 'w').write('''
+    >>> f.close()
+    >>> f = open('config2', 'w')
+    >>> _ = f.write('''
     ... <zodb db>
     ...     <filestorage>
     ...         pack-gc false
@@ -176,6 +183,7 @@ def test_missmatched_configs():
     ...     </filestorage>
     ... </zodb>
     ... ''')
+    >>> f.close()
     >>> bad = zc.zodbdgc.gc('config1', conf2='config2')
     Traceback (most recent call last):
     ...
@@ -203,4 +211,3 @@ def test_suite():
             setUp=setupstack.setUpDirectory, tearDown = setupstack.tearDown,
             ))
     return suite
-

--- a/src/zc/zodbdgc/tests.py
+++ b/src/zc/zodbdgc/tests.py
@@ -59,7 +59,9 @@ First, open a database and create some data:
     ... </zodb>
     ... ''')
     >>> f.close()
-    >>> db = ZODB.config.databaseFromFile(open('config'))
+
+    >>> with open('config', 'r') as f:
+    ...     db = ZODB.config.databaseFromFile(f)
     >>> conn = db.open()
     >>> for i in range(9):
     ...     conn.root()[i] = conn.root().__class__()
@@ -106,7 +108,8 @@ Now GC. We should lose 3 objects:
      ('', ...'\x00\x00\x00\x00\x00\x00\x00\x02'),
      ('', ...'\x00\x00\x00\x00\x00\x00\x00\x03')]
 
-    >>> db = ZODB.config.databaseFromFile(open('config'))
+    >>> with open('config', 'r') as f:
+    ...     db = ZODB.config.databaseFromFile(f)
     >>> db.pack()
     >>> len(db.storage)
     7
@@ -129,7 +132,8 @@ def stupid_typo_nameerror_not():
     >>> f.close()
     >>> import persistent.mapping, time
     >>> with mock.patch("time.time", return_value=1241458549.614022):
-    ...     db = ZODB.config.databaseFromFile(open('config'))
+    ...     with open('config') as f:
+    ...          db = ZODB.config.databaseFromFile(f)
     ...     conn = db.open()
     ...     junk = persistent.mapping.PersistentMapping()
     ...     conn.add(junk)
@@ -150,7 +154,8 @@ def stupid_typo_nameerror_not():
     ...     for name, oid in sorted(bad.iterator()):
     ...         print( "{0} {1}".format(name, u64(oid)) )
     ...     time.time.return_value += 86400*1.5
-    ...     db = ZODB.config.databaseFromFile(open('config'))
+    ...     with open('config', 'r') as f:
+    ...         db = ZODB.config.databaseFromFile(f)
     ...     len(db.storage)
     ...     db.pack()
     ...     len(db.storage)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,15 @@
 [tox]
-envlist = py26,py27,py32,py33,py34,pypy,pypy3
+envlist = py26,py27,py32,py33,py34,pypy
+#,pypy3
+
+# PyPy3-2.4.0 fails to lock the files:
+#   zc/lockfile/__init__.py", line 57, in _lock_file
+#    fcntl.flock(file.fileno(), _flags)
+#   IOError: [Errno 35] Resource temporarily unavailable
+# This could be a GC issue in zc.lockfile 1.1.0 due to all the ResourceWarnings about
+# unclosed files:
+#    ResourceWarning: unclosed file <_io.TextIOWrapper name='1.fs.lock' mode='a+' encoding='US-ASCII'>
+# OTOH, at this writing PyPy3 is a major version behind PyPy (2.4 vs 2.5).
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,5 @@
 [tox]
-envlist = py26,py27,py32,py33,py34,pypy
-#,pypy3
-
-# PyPy3-2.4.0 fails to lock the files:
-#   zc/lockfile/__init__.py", line 57, in _lock_file
-#    fcntl.flock(file.fileno(), _flags)
-#   IOError: [Errno 35] Resource temporarily unavailable
-# This could be a GC issue in zc.lockfile 1.1.0 due to all the ResourceWarnings about
-# unclosed files:
-#    ResourceWarning: unclosed file <_io.TextIOWrapper name='1.fs.lock' mode='a+' encoding='US-ASCII'>
-# OTOH, at this writing PyPy3 is a major version behind PyPy (2.4 vs 2.5).
+envlist = py26,py27,py32,py33,py34,pypy,pypy3
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -4,4 +4,4 @@ envlist = py26,py27,py32,py33,py34,pypy,pypy3
 [testenv]
 deps =
 commands =
-    python setup.py test -q
+    python setup.py -q test

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,7 @@
+[tox]
+envlist = py26,py27,py32,py33,py34,pypy,pypy3
+
+[testenv]
+deps =
+commands =
+    python setup.py test -q


### PR DESCRIPTION
This PR adds support for versions of Python > 2.6 and PyPy by using `zodbpickle` when needed. 

As summarized in [the zodbpickle issue](https://github.com/zopefoundation/zodbpickle/issues/9), `noload` is broken in CPython 2.7, as well as being completely missing in PyPy and Python 3. `zodbpickle` fixes this for CPython 2.7 and adds it back for PyPy and Python 3.

The tests were initially broken under 2.6 due to changes in the latest ZODB/persistent, so the first/fourth commit fixes those tests. Then CPython 2.7 support was added by creating a dependency on `zodbpickle` and using it when needed. Fixing PyPy support was a matter of ensuring that resources get closed in a timely fashion, and Python 3 support consisted of some minor syntax changes to account for the `print` statement and the differences between bytes and strings, plus one `__bool__` alias. 

A `tox.ini` for local use and a `.travis.yml` file for github use were added to ensure the tests run on all supported platforms (this required a `MANIFEST.in` for tox):

```
$ tox
.....
____________________ summary __________________________
  py26: commands succeeded
  py27: commands succeeded
  py32: commands succeeded
  py33: commands succeeded
  py34: commands succeeded
  pypy: commands succeeded
```

The smelliest part is that a monkey-patch against `ZODB.serialize` is necessary to work with older versions of ZODB that don't properly support PyPy (since it has never had a version of `noload`). I can submit a PR for ZODB to fix that problem going forward.