### PR TITLE
Release cleanups

### DIFF
--- a/.pep8
+++ b/.pep8
@@ -1,0 +1,4 @@
+[pep8]
+ignore=E302,E261,E129
+max_line_length=90
+exclude=.eggs,.tox,.git,build,dist,

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,12 +8,13 @@
 - Add support for PyPy, Python 2.7, and Python 3.
   This requires the addition of the ``zodbpickle`` dependency, even on
   Python 2.6.
-
+- Fixed the ``--days`` argument to ``multi-zodb-gc`` with recent
+  versions of ``persistent``.
 
 0.6.1 2012-10-08
 ================
 
-Fixed: GC could fail it special cases with a NameError.
+- Fixed: GC could fail it special cases with a NameError.
 
 0.6.0 2010-05-27
 ================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,25 +11,25 @@
 - Fixed the ``--days`` argument to ``multi-zodb-gc`` with recent
   versions of ``persistent``.
 
-0.6.1 2012-10-08
-================
+0.6.1 (2012-10-08)
+==================
 
 - Fixed: GC could fail it special cases with a NameError.
 
-0.6.0 2010-05-27
-================
+0.6.0 (2010-05-27)
+==================
 
 - Added support for storages with transformed (e.g. compressed) data
   records.
 
-0.5.0 2009-11-10
-================
+0.5.0 (2009-11-10)
+==================
 
 - Fixed a bug in the delay throttle that made it delete objects way
   too slowly.
 
-0.4.0 2009-09-08
-================
+0.4.0 (2009-09-08)
+==================
 
 - The previous version deleted too many objects at a time, which could
   put too much load on a heavily loaded storage server.
@@ -40,8 +40,8 @@
   - Adjust the deletion batch size to take about .5 seconds per
     batch of deletions, but do at least 10 at a time.
 
-0.3.0 2009-09-03
-================
+0.3.0 (2009-09-03)
+==================
 
 - Optimized garbage collection by using a temporary file to
   store object references rather than loading them from the analysis
@@ -54,14 +54,14 @@
   database to build an index and avoids the memory cost of a
   file-storage index.
 
-0.2.0 2009-06-15
-================
+0.2.0 (2009-06-15)
+==================
 
 - Added an option to ignore references to some databases.
 
 - Fixed a bug in handling of the logging level option.
 
-0.1.0 2009-06-11
-================
+0.1.0 (2009-06-11)
+==================
 
 Initial release

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,0 +1,66 @@
+================
+ Change History
+================
+
+0.7.0 (unreleased)
+==================
+
+- Add support for PyPy, Python 2.7, and Python 3.
+  This requires the addition of the ``zodbpickle`` dependency, even on
+  Python 2.6.
+
+
+0.6.1 2012-10-08
+================
+
+Fixed: GC could fail it special cases with a NameError.
+
+0.6.0 2010-05-27
+================
+
+- Added support for storages with transformed (e.g. compressed) data
+  records.
+
+0.5.0 2009-11-10
+================
+
+- Fixed a bug in the delay throttle that made it delete objects way
+  too slowly.
+
+0.4.0 2009-09-08
+================
+
+- The previous version deleted too many objects at a time, which could
+  put too much load on a heavily loaded storage server.
+
+  - Add a sleep or allow the storage to rest after a set of deletions.
+    Sleep for twice the time taken to perform the deletions.
+
+  - Adjust the deletion batch size to take about .5 seconds per
+    batch of deletions, but do at least 10 at a time.
+
+0.3.0 2009-09-03
+================
+
+- Optimized garbage collection by using a temporary file to
+  store object references rather than loading them from the analysis
+  database when needed.
+
+- Added an -f option to specify file-storage files directly.  It is
+  wildly faster to iterate over a file storage than over a ZEO
+  connection.  Using this option uses a file iterator rather than
+  opening a file storage in read-only mode, which avoids scanning the
+  database to build an index and avoids the memory cost of a
+  file-storage index.
+
+0.2.0 2009-06-15
+================
+
+- Added an option to ignore references to some databases.
+
+- Fixed a bug in handling of the logging level option.
+
+0.1.0 2009-06-11
+================
+
+Initial release

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,8 @@
 include *.txt
 include *.rst
-exclude buildout.cfg
-exclude tox.ini
+include buildout.cfg
+include tox.ini
+include .pep8
 
 recursive-include src *
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,7 @@
 include *.txt
 include *.rst
+exclude buildout.cfg
+exclude tox.ini
 
 recursive-include src *
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[zest.releaser]
+create-wheel = yes

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
+[bdist_wheel]
+universal = 1
+
 [zest.releaser]
 create-wheel = yes

--- a/setup.py
+++ b/setup.py
@@ -35,12 +35,12 @@ long_description = (
         '--------\n'
         )
 
-tests_require = ['zope.testing', 'mock']
+tests_require = ['zope.testing', 'mock >= 1.3.0']
 install_requires = [
     "BTrees >= 4.0.0",
     "ZODB >= 4.0.0",
     "persistent >= 4.0.0",
-    "setuptools",
+    "setuptools >= 17.1",
     "transaction",
     # PyPy, Jython, and Py3K don't have cPickle's `noload`, and `noload` is broken in CPython >= 2.7.
     # Use zodbpickle everywhere, even on cPython 2.6, for consistency and to avoid

--- a/setup.py
+++ b/setup.py
@@ -30,11 +30,13 @@ def read(rname):
         return f.read()
 
 long_description = (
-        read('src/%s/README.txt' % '/'.join(name.split('.')))
-        + '\n' +
-        'Download\n'
-        '--------\n'
-        )
+    read('src/%s/README.txt' % '/'.join(name.split('.')))
+    + '\n' +
+    read('CHANGES.rst')
+    + '\n' +
+    'Download\n'
+    '========\n'
+)
 
 tests_require = ['zope.testing', 'mock >= 1.3.0']
 install_requires = [
@@ -57,6 +59,8 @@ setup(
     description = 'ZODB Distributed Garbage Collection',
     long_description=long_description,
     license = 'ZPL 2.1',
+    url = "https://github.com/zopefoundation/zc.zodbdgc",
+    keywords = "database nosql python zope zodb garbage collection distributed",
 
     packages = ['zc', 'zc.zodbdgc'],
     namespace_packages = ['zc'],

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,8 @@
 #
 ##############################################################################
 
-name, version = 'zc.zodbdgc', '0.6.2.dev0'
+name = 'zc.zodbdgc'
+version = '0.7.0.dev0'
 
 import os
 import sys

--- a/setup.py
+++ b/setup.py
@@ -45,36 +45,38 @@ install_requires = [
     "persistent >= 4.0.0",
     "setuptools >= 17.1",
     "transaction",
-    # PyPy, Jython, and Py3K don't have cPickle's `noload`, and `noload` is broken in CPython >= 2.7.
-    # Use zodbpickle everywhere, even on cPython 2.6, for consistency and to avoid
-    # issues with wheels and dynamic install_requires.
+    # PyPy, Jython, and Py3K don't have cPickle's `noload`, and `noload`
+    # is broken in CPython >= 2.7. Use zodbpickle everywhere, even on
+    # cPython 2.6, for consistency and to avoid issues with wheels and
+    # dynamic install_requires.
     "zodbpickle",
-    ]
+]
+
 
 setup(
-    name = name,
-    version = version,
-    author = 'Jim Fulton',
-    author_email = 'jim@zope.com',
-    description = 'ZODB Distributed Garbage Collection',
+    name=name,
+    version=version,
+    author='Jim Fulton',
+    author_email='jim@zope.com',
+    description='ZODB Distributed Garbage Collection',
     long_description=long_description,
-    license = 'ZPL 2.1',
-    url = "https://github.com/zopefoundation/zc.zodbdgc",
-    keywords = "database nosql python zope zodb garbage collection distributed",
+    license='ZPL 2.1',
+    url="https://github.com/zopefoundation/zc.zodbdgc",
+    keywords="database nosql python zope zodb garbage collection distributed",
 
-    packages = ['zc', 'zc.zodbdgc'],
-    namespace_packages = ['zc'],
-    package_dir = {'': 'src'},
+    packages=['zc', 'zc.zodbdgc'],
+    namespace_packages=['zc'],
+    package_dir={'': 'src'},
     install_requires=install_requires,
-    zip_safe = False,
+    zip_safe=False,
     entry_points=entry_points,
-    include_package_data = True,
+    include_package_data=True,
     tests_require=tests_require,
     extras_require=dict(
         test=tests_require,
-        ),
+    ),
     test_suite='zc.zodbdgc.tests.test_suite',
-	classifiers=[
+    classifiers=[
         "Framework :: ZODB"
         "License :: OSI Approved :: Zope Public License",
         "Operating System :: OS Independent",
@@ -89,4 +91,4 @@ setup(
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
     ],
-    )
+)

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,6 @@
 name, version = 'zc.zodbdgc', '0.6.2.dev0'
 
 import os
-import platform
 import sys
 from setuptools import setup, find_packages
 
@@ -43,18 +42,11 @@ install_requires = [
     "persistent >= 4.0.0",
     "setuptools",
     "transaction",
+    # PyPy, Jython, and Py3K don't have cPickle's `noload`, and `noload` is broken in CPython >= 2.7.
+    # Use zodbpickle everywhere, even on cPython 2.6, for consistency and to avoid
+    # issues with wheels and dynamic install_requires.
+    "zodbpickle",
     ]
-
-# PyPy, Jython, and Py3K don't have cPickle's `noload`, and `noload` is broken in CPython >= 2.7
-py_impl = getattr(platform, 'python_implementation', lambda: None)
-is_pypy = py_impl() == 'PyPy'
-is_jython = py_impl() == 'Jython'
-py3k = sys.version_info >= (3, )
-py27 = sys.version_info >= (2, 7)
-
-if is_pypy or is_jython or py27 or py3k:
-    install_requires.append('zodbpickle')
-
 
 setup(
     name = name,

--- a/setup.py
+++ b/setup.py
@@ -25,8 +25,8 @@ multi-zodb-check-refs = zc.zodbdgc:check_command
 """
 
 def read(rname):
-    return open(os.path.join(os.path.dirname(__file__), *rname.split('/')
-                             )).read()
+    with open(os.path.join(os.path.dirname(__file__), *rname.split('/'))) as f:
+        return f.read()
 
 long_description = (
         read('src/%s/README.txt' % '/'.join(name.split('.')))

--- a/src/zc/zodbdgc/README.txt
+++ b/src/zc/zodbdgc/README.txt
@@ -72,10 +72,12 @@ information.
 Change History
 ==============
 
-0.6.2 (unreleased)
+0.7.0 (unreleased)
 ----------------
 
 - Add support for PyPy, Python 2.7, and Python 3.
+  This requires the addition of the ``zodbpickle`` dependency, even on
+  Python 2.6.
 
 
 0.6.1 2012-10-08

--- a/src/zc/zodbdgc/README.txt
+++ b/src/zc/zodbdgc/README.txt
@@ -1,5 +1,6 @@
-ZODB Distributed GC
-===================
+=====================
+ ZODB Distributed GC
+=====================
 
 This package provides 2 scripts, for multi-database garbage collection
 and database validation.
@@ -10,7 +11,7 @@ databases support efficient iteration from transactions near the end
 of the databases.
 
 multi-zodb-gc
--------------
+=============
 
 The multi-zodb-gc script takes one or 2 configuration files.  If a
 single configuration file is given, garbage collection is performed on
@@ -46,7 +47,7 @@ be treated as non garbage and to specify the logging level.  Use the
 
 
 multi-zodb-check-refs
----------------------
+=====================
 
 The multi-zodb-check-refs script validates a collection of databases
 by starting with their roots and traversing the databases to make sure
@@ -68,69 +69,3 @@ problems are found.
 
 You can run the script with the ``--help`` option to get usage
 information.
-
-Change History
-==============
-
-0.7.0 (unreleased)
-----------------
-
-- Add support for PyPy, Python 2.7, and Python 3.
-  This requires the addition of the ``zodbpickle`` dependency, even on
-  Python 2.6.
-
-
-0.6.1 2012-10-08
-----------------
-
-Fixed: GC could fail it special cases with a NameError.
-
-0.6.0 2010-05-27
-----------------
-
-- Added support for storages with transformed (e.g. compressed) data
-  records.
-
-0.5.0 2009-11-10
-----------------
-
-- Fixed a bug in the delay throttle that made it delete objects way
-  too slowly.
-
-0.4.0 2009-09-08
-----------------
-
-- The previous version deleted too many objects at a time, which could
-  put too much load on a heavily loaded storage server.
-
-  - Add a sleep or allow the storage to rest after a set of deletions.
-    Sleep for twice the time taken to perform the deletions.
-
-  - Adjust the deletion batch size to take about .5 seconds per
-    batch of deletions, but do at least 10 at a time.
-
-0.3.0 2009-09-03
-----------------
-
-- Optimized garbage collection by using a temporary file to
-  store object references rather than loading them from the analysis
-  database when needed.
-
-- Added an -f option to specify file-storage files directly.  It is
-  wildly faster to iterate over a file storage than over a ZEO
-  connection.  Using this option uses a file iterator rather than
-  opening a file storage in read-only mode, which avoids scanning the
-  database to build an index and avoids the memory cost of a
-  file-storage index.
-
-0.2.0 2009-06-15
-----------------
-
-- Added an option to ignore references to some databases.
-
-- Fixed a bug in handling of the logging level option.
-
-0.1.0 2009-06-11
-----------------
-
-Initial release

--- a/src/zc/zodbdgc/__init__.py
+++ b/src/zc/zodbdgc/__init__.py
@@ -33,7 +33,8 @@ except ImportError:
 # under PyPy, etc, and hence have broken functions at `ZODB.serialize.referencesf`
 # and `ZODB.serialize.get_refs`. Check for that and patch it.
 import ZODB.serialize
-if hasattr(ZODB.serialize, 'Unpickler') and not hasattr(ZODB.serialize.Unpickler, 'noload'):
+if (hasattr(ZODB.serialize, 'Unpickler')
+    and not hasattr(ZODB.serialize.Unpickler, 'noload')):
     ZODB.serialize.Unpickler = Unpickler
 
 from io import BytesIO
@@ -59,11 +60,13 @@ import ZODB.POSException
 if hasattr(dict(), 'iteritems'):
     def _iteritems(d):
         return d.iteritems()
+
     def _itervalues(d):
         return d.itervalues()
 else:
     def _iteritems(d):
         return d.items()
+
     def _itervalues(d):
         return d.values()
 
@@ -110,7 +113,7 @@ def gc_command(args=None, ptid=None):
     if not args or len(args) > 2:
         parser.parse_args(['-h'])
     elif len(args) == 2:
-        conf2=args[1]
+        conf2 = args[1]
     else:
         conf2 = None
 
@@ -180,8 +183,8 @@ def gc_(close, conf, days, ignore, conf2, fs, untransform, ptid):
 
     if ptid is None:
         ptid = TimeStamp.TimeStamp(
-                *time.gmtime(time.time() - 86400*days)[:6]
-                ).raw()
+            *time.gmtime(time.time() - 86400 * days)[:6]
+        ).raw()
 
     good = oidset(databases)
     bad = Bad(databases)
@@ -191,7 +194,9 @@ def gc_(close, conf, days, ignore, conf2, fs, untransform, ptid):
     # it can speed up GC because it avoids file writes.)
     # OTOH, not closing Bad yields ResourceWarnings under Py3
     # and (temporarily?) leaks files under PyPy/Jython.
-    #close.append(bad)
+
+    # close.append(bad)
+
     deleted = oidset(databases)
 
     for name, storage in storages:
@@ -218,7 +223,7 @@ def gc_(close, conf, days, ignore, conf2, fs, untransform, ptid):
 
             for trans in it:
                 for record in trans:
-                    if n and n%10000 == 0:
+                    if n and n % 10000 == 0:
                         logger.info("%s: %s recent", name, n)
                     n += 1
 
@@ -251,7 +256,7 @@ def gc_(close, conf, days, ignore, conf2, fs, untransform, ptid):
 
         for trans in it:
             for record in trans:
-                if n and n%10000 == 0:
+                if n and n % 10000 == 0:
                     logger.info("%s: %s old", name, n)
                 n += 1
 
@@ -308,9 +313,9 @@ def gc_(close, conf, days, ignore, conf2, fs, untransform, ptid):
                 storage.tpc_finish(t)
                 t.commit()
                 logger.info("%s: deleted %s", name, nd)
-                duration = time.time()-start
-                time.sleep(duration*2)
-                batch_size = max(10, int(batch_size*.5/duration))
+                duration = time.time() - start
+                time.sleep(duration * 2)
+                batch_size = max(10, int(batch_size * .5 / duration))
                 t = transaction.begin()
                 storage.tpc_begin(t)
                 start = time.time()
@@ -383,13 +388,13 @@ class oidset(dict):
     def pop(self):
         for name, data in _iteritems(self):
             if data:
-               break
+                break
         prefix, s = next(iter(_iteritems(data)))
         suffix = s.maxKey()
         s.remove(suffix)
         if not s:
             del data[prefix]
-        return name, prefix+suffix
+        return name, prefix + suffix
 
     def has(self, name, oid):
         try:
@@ -406,7 +411,7 @@ class oidset(dict):
         else:
             for prefix, data in _iteritems(self[name]):
                 for suffix in data:
-                    yield prefix+suffix
+                    yield prefix + suffix
 
 class Bad(object):
 
@@ -473,7 +478,7 @@ class Bad(object):
             return ()
         del db[oid]
         f = self._file
-        f.seek(pos+8)
+        f.seek(pos + 8)
         return marshal.load(f)
 
 
@@ -565,29 +570,27 @@ def check_(config, references=None):
                 if not seen.insert(name, oid):
                     continue
                 p, tid = storages[name].load(oid, b'')
-                if (
-                    # XXX should be in is_blob_record
+                if (# XXX should be in is_blob_record
                     len(p) < 100 and (b'ZODB.blob' in p)
-
-                    and ZODB.blob.is_blob_record(p)
-                    ):
+                        and ZODB.blob.is_blob_record(p)
+                ):
                     storages[name].loadBlob(oid, tid)
             except:
-                print( '!!!', name, u64(oid), end=' ')
+                print('!!!', name, u64(oid), end=' ')
 
                 referer = _get_referer(references, name, oid)
                 if referer:
                     rname, roid = referer
-                    print( rname, u64(roid) )
+                    print(rname, u64(roid))
                 else:
-                    print( '?' )
+                    print('?')
                 t, v = sys.exc_info()[:2]
-                print( "%s: %s" % (t.__name__, v))
+                print("%s: %s" % (t.__name__, v))
                 continue
 
             for ref in getrefs(p, name, ()):
                 if (ref[0] != name) and not databases[name].xrefs:
-                    print( 'bad xref', ref[0], u64(ref[1]), name, u64(oid))
+                    print('bad xref', ref[0], u64(ref[1]), name, u64(oid))
 
                 nreferences += _insert_ref(references, name, oid, *ref)
 
@@ -596,8 +599,8 @@ def check_(config, references=None):
                     nreferences = 0
 
                 if ref[0] not in databases:
-                    print( '!!!', ref[0], u64(ref[1]), name, u64(oid))
-                    print( 'bad db')
+                    print('!!!', ref[0], u64(ref[1]), name, u64(oid))
+                    print('bad db')
                     continue
                 if seen.has(*ref):
                     continue

--- a/src/zc/zodbdgc/tests.py
+++ b/src/zc/zodbdgc/tests.py
@@ -200,19 +200,19 @@ def test_suite():
     suite = unittest.TestSuite((
         doctest.DocFileSuite(
             'README.test', 'oidset.test',
-            setUp=setupstack.setUpDirectory, tearDown = setupstack.tearDown,
+            setUp=setupstack.setUpDirectory, tearDown=setupstack.tearDown,
             checker=renormalizing.RENormalizing([
                 (re.compile('usage'), 'Usage'),
                 (re.compile('options'), 'Options'),
-                ]),
-            ),
-        ))
+            ]),
+        ),
+    ))
     try:
         import ZODB.tests.hexstorage
     except ImportError:
         pass
     else:
         suite.addTest(doctest.DocTestSuite(
-            setUp=setupstack.setUpDirectory, tearDown = setupstack.tearDown,
-            ))
+            setUp=setupstack.setUpDirectory, tearDown=setupstack.tearDown,
+        ))
     return suite

--- a/tox.ini
+++ b/tox.ini
@@ -3,5 +3,6 @@ envlist = py26,py27,py32,py33,py34,pypy,pypy3
 
 [testenv]
 deps =
+    setuptools >= 17.1
 commands =
     python setup.py -q test


### PR DESCRIPTION
Working on changes mentioned in #3 and general cleanups for release. Pending the outcome of the discussion about the ``ResourceWarning``s and version numbering; if we decide to make changes to fix ``ResourceWarning``s, I currently expect to merge this and start a new branch/PR to fix those.

* Non-dynamic dependency on ``zodbpickle`` for better support of wheels.
* Compatibility with zest.releaser (move changes to their own file, explicit version attribute, manifest and setup.py cleanups).
* Pep8 cleanup (lots of whitespace changes, try the ?w=0 query param).
* Fix possible performance regression on Python 2 (.items() vs .iteritems())