### PR TITLE
Use TransactionMetaData and fix #14

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,11 @@
+[run]
+source = zc.zodbdgc
+
+
+[report]
+exclude_lines =
+    pragma: no cover
+    def __repr__
+    raise AssertionError
+    raise NotImplementedError
+    if __name__ == .__main__.:

--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,7 @@ eggs
 develop-eggs
 .dir-locals.el
 .tox
+coverage.xml
+htmlcov/
+.coverage
 .coverage.*

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ eggs
 develop-eggs
 .dir-locals.el
 .tox
+.coverage.*

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,18 +6,25 @@ python:
     - 3.6
     - 3.7
     - 3.8
+    - 3.9-dev
     - pypy3
-install:
-    # First install a newer pip so that it can use the wheel cache
-    # (only needed until travis upgrades pip to 7.x)
-    - travis_retry pip install -U pip
-    - pip install -U ".[test]"
+env:
+  global:
+    - PYTHONHASHSEED=1042466059
+    - ZOPE_INTERFACE_STRICT_IRO=1
+
 script:
-    - python setup.py test -q
-notifications:
-    email: false
-cache:
-  directories:
-    - $HOME/.cache/pip
+  - coverage run -m zope.testrunner --test-path=src  --auto-color --auto-progress
+
+after_success:
+  - coveralls
+
+install:
+  - pip install -U pip setuptools
+  - pip install -U coveralls coverage
+  - pip install -U -e ".[test]"
+
+cache: pip
+
 before_cache:
     - rm -f $HOME/.cache/pip/log/debug.log

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,13 +2,14 @@
  Change History
 ================
 
-1.0.2 (unreleased)
+1.1.0 (unreleased)
 ==================
 
-- Add support for Python 3.5, 3.6, 3.7 and 3.8.
+- Add support for Python 3.5, 3.6, 3.7, 3.8 and 3.9.
 
 - Drop support for Python for Python 2.6, 3.2, 3.3 and 3.4.
 
+- Require ZODB 5.1 or later.
 
 1.0.1 (2015-09-23)
 ==================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,7 +9,7 @@
 
 - Drop support for Python for Python 2.6, 3.2, 3.3 and 3.4.
 
-- Require ZODB 5.1 or later.
+- Require ZODB 5.1 or later. See `issue 14 <https://github.com/zopefoundation/zc.zodbdgc/issues/14>`_.
 
 1.0.1 (2015-09-23)
 ==================

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,7 @@ include *.rst
 include buildout.cfg
 include tox.ini
 include .pep8
+include .coveragerc
 
 recursive-include src *
 

--- a/setup.py
+++ b/setup.py
@@ -12,12 +12,12 @@
 #
 ##############################################################################
 
-name = 'zc.zodbdgc'
-version = '1.0.2.dev0'
-
 import os
-import sys
-from setuptools import setup, find_packages
+from setuptools import setup
+
+name = 'zc.zodbdgc'
+version = '1.1.0.dev0'
+
 
 entry_points = """
 [console_scripts]
@@ -38,10 +38,14 @@ long_description = (
     '========\n'
 )
 
-tests_require = ['zope.testing', 'mock >= 1.3.0']
+tests_require = [
+    'zope.testing',
+    'mock >= 1.3.0',
+    'zope.testrunner',
+]
 install_requires = [
     "BTrees >= 4.0.0",
-    "ZODB >= 4.0.0",
+    "ZODB >= 5.1.0", # TransactionMetaData added in 5.1
     "persistent >= 4.0.0",
     "setuptools >= 17.1",
     "transaction",
@@ -88,6 +92,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
     ],

--- a/src/zc/zodbdgc/__init__.py
+++ b/src/zc/zodbdgc/__init__.py
@@ -48,15 +48,6 @@ try:
 except ImportError:
     from zodbpickle.pickle import Unpickler
 
-# Older versions of ZODB aren't aware of needing to use zodbpickle
-# under PyPy, etc, and hence have broken functions at `ZODB.serialize.referencesf`
-# and `ZODB.serialize.get_refs`. Check for that and patch it.
-
-if (hasattr(ZODB.serialize, 'Unpickler')
-    and not hasattr(ZODB.serialize.Unpickler, 'noload')):
-    ZODB.serialize.Unpickler = Unpickler
-
-
 # In cases where we might iterate multiple times
 # over large-ish dictionaries, avoid excessive copies
 # that tend toward O(n^2) complexity by using the explicit

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,12 @@
 [tox]
-envlist = py27,py35,py36,py37,py38,py39,pypy,pypy3
+envlist = py27,py35,py36,py37,py38,py39,pypy,pypy3,coverage
 
 [testenv]
+# usedevolop is an easy way to fix multiple paths
+# not matching in the coverage output.
+usedevelop = true
 extras = test
+deps = coverage
 commands =
     coverage run -p -m zope.testrunner --test-path=src  --auto-color --auto-progress [] # substitute with tox positional args
 setenv =
@@ -10,6 +14,7 @@ setenv =
     ZOPE_INTERFACE_STRICT_IRO=1
 
 [testenv:coverage]
+deps = coverage
 commands =
     coverage combine
     coverage report -i

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,19 @@
 [tox]
-envlist = py27,py35,py36,py37,py38,pypy,pypy3
+envlist = py27,py35,py36,py37,py38,py39,pypy,pypy3
 
 [testenv]
-deps =
-    setuptools >= 17.1
-    mock <= 3.0.5; python_version == "2.7"
+extras = test
 commands =
-    python setup.py -q test
+    coverage run -p -m zope.testrunner --test-path=src  --auto-color --auto-progress [] # substitute with tox positional args
+setenv =
+    PYTHONHASHSEED=1042466059
+    ZOPE_INTERFACE_STRICT_IRO=1
+
+[testenv:coverage]
+commands =
+    coverage combine
+    coverage report -i
+    coverage html -i
+    coverage xml -i
+depends = py27,py36,py37,py38,py39,pypy,pypy3
+parallel_show_output = true


### PR DESCRIPTION
And various small metadata updates
  - Depend on ZODB version that includes TransactionMetaData
  - Add Python 3.9
  - Use coverage in tox and on travis

Fixes #14